### PR TITLE
add wizard to set up params

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - "prometheus_data:/prometheus"
       - "prometheus_file_sd:/prometheus_file_sd"
+    environment:
+      RETENTION: 15
   manager:
     build: ./manager
     image: "manager.dms.dnp.dappnode.eth:1.0.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "prometheus_data:/prometheus"
       - "prometheus_file_sd:/prometheus_file_sd"
     environment:
-      RETENTION: 15
+      DATA_RETENTION_DAYS: 15
   manager:
     build: ./manager
     image: "manager.dms.dnp.dappnode.eth:1.0.1"

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,3 +1,8 @@
 FROM prom/prometheus
 
 COPY prometheus.yml /etc/prometheus/
+
+ENTRYPOINT [ "sh","-c","/bin/prometheus --config.file=/etc/prometheus/prometheus.yml \ 
+    --storage.tsdb.path=/prometheus \
+    --web.console.libraries=/usr/share/prometheus/console_libraries  \ 
+    --storage.tsdb.retention.time=${RETENTION}d" ]

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -5,4 +5,4 @@ COPY prometheus.yml /etc/prometheus/
 ENTRYPOINT [ "sh","-c","/bin/prometheus --config.file=/etc/prometheus/prometheus.yml \ 
     --storage.tsdb.path=/prometheus \
     --web.console.libraries=/usr/share/prometheus/console_libraries  \ 
-    --storage.tsdb.retention.time=${RETENTION}d" ]
+    --storage.tsdb.retention.time=${DATA_RETENTION_DAYS}d" ]

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -1,0 +1,14 @@
+version: "2"
+fields:
+  - id: log-retention-time
+    target:
+      type: environment
+      name: RETENTION
+      service: prometheus
+    title: Log Retention Time
+    description: >-
+      Define how much time the logs/data of your applications will be stored. By default, this time is set up to 15 days. 
+      Take care of using a big number because the logs can occupy so much disk space. The unit measure is days. So if you define 30, the retention time will be 30 days.
+    pattern: "^[0-9]*$"
+    patternErrorMessage: "The input must contain only numbers."
+    required: false

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -3,7 +3,7 @@ fields:
   - id: log-retention-time
     target:
       type: environment
-      name: RETENTION
+      name: DATA_RETENTION_DAYS
       service: prometheus
     title: Log Retention Time
     description: >-


### PR DESCRIPTION
* Define the environment variable RETENTION in order to set up how much time the data will be stored (by default they are stored during 15d).
*  Override the ENTRYPOINT of the package, including this new option of Prometheus `--storage.tsdb.retention.time=`
* Create a wizard for this package to make easier this functionality.

Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/607 