### PR TITLE
Fix

### DIFF
--- a/manager/package.json
+++ b/manager/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha \"./{,!(node_modules)/**}/*.test.ts\" ",
-    "build": "webpack",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider; webpack",
     "check:types": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
The build command does not work currently on this node version because of openssl 3.0, it's required to use this version on the build script, it's the solution for now:
https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
