### PR TITLE
Update grafana version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: "3.4"
 services:
   grafana:
-    build: 
+    build:
       context: grafana
       args:
-        UPSTREAM_VERSION: 8.1.5
+        UPSTREAM_VERSION: 8.1.8
     image: "grafana.dms.dnp.dappnode.eth:1.0.1"
     restart: always
     volumes:
       - "grafana_data:/var/lib/grafana"
   prometheus:
-    build: 
+    build:
       context: prometheus
       args:
         UPSTREAM_VERSION: v2.30.0


### PR DESCRIPTION
This update to he version 8.1.8 version , this version fix the CVE which was found few days ago (https://www.bleepingcomputer.com/news/security/grafana-fixes-zero-day-vulnerability-after-exploits-spread-over-twitter/).