### PR TITLE
Fix typo in exporter dependency

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/dappnode/DMS/issues"
   },
   "dependencies": {
-    "exporter.dnp.dappnode.eth": "latest"
+    "dappnode-exporter.dnp.dappnode.eth": "latest"
   },
   "license": "GPL-3.0"
 }


### PR DESCRIPTION
Exporter package was misspelled in `dappnode_package.json` dependencies