### PR TITLE
Specify dms's prometheus

### DIFF
--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -5,7 +5,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://prometheus:9090
+    url: http://prometheus.dms.dappnode:9090
     basicAuth: false
     isDefault: true
     editable: true


### PR DESCRIPTION
`http://prometheus:9090` could be multiple prometheus, if dappnode has multiple prometheus installed.

This can lead to grafana showing "no data" panels, since not all prometheus have all metrics 